### PR TITLE
fix(schemas): support WKBElement with Pydantic

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -489,6 +489,19 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "shapely"
+version = "1.8.2"
+description = "Geometric objects, predicates, and operations"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+all = ["pytest", "pytest-cov", "numpy"]
+test = ["pytest", "pytest-cov"]
+vectorized = ["numpy"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -632,7 +645,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9, <4.0"
-content-hash = "bdbbd0b2b1e3b255d252685f66042dce00a37c234539c3241a4e62caca035463"
+content-hash = "b3945cb1b209a41eabd4fffa34d3d67ee59f6249b9148b96641f3597f790a04c"
 
 [metadata.files]
 alembic = [
@@ -1096,6 +1109,42 @@ pyyaml = [
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+shapely = [
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c9e3400b716c51ba43eea1678c28272580114e009b6c78cdd00c44df3e325fa"},
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce0b5c5f7acbccf98b3460eecaa40e9b18272b2a734f74fcddf1d7696e047e95"},
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3a40bf497b57a6625b83996aed10ce2233bca0e5471b8af771b186d681433ac5"},
+    {file = "Shapely-1.8.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6bdc7728f1e5df430d8c588661f79f1eed4a2728c8b689e12707cfec217f68f8"},
+    {file = "Shapely-1.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a60861b5ca2c488ebcdc706eca94d325c26d1567921c74acc83df5e6913590c7"},
+    {file = "Shapely-1.8.2-cp310-cp310-win32.whl", hash = "sha256:840be3f27a1152851c54b968f2e12d718c9f13b7acd51c482e58a70f60f29e31"},
+    {file = "Shapely-1.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:c60f3758212ec480675b820b13035dda8af8f7cc560d2cc67999b2717fb8faef"},
+    {file = "Shapely-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:56413f7d32c70b63f239eb0865b24c0c61029e38757de456cc4ab3c416559a0b"},
+    {file = "Shapely-1.8.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:256bdf8080bb7bb504d47b2c76919ecebab9708cc1b26266b3ec32b42448f642"},
+    {file = "Shapely-1.8.2-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0a0d7752b145343838bd36ed09382d85f5befe426832d7384c5b051c147acbd"},
+    {file = "Shapely-1.8.2-cp36-cp36m-win32.whl", hash = "sha256:62056e64b12b6d483d79f8e34bf058d2fe734d51c9227c1713705399434eff3b"},
+    {file = "Shapely-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:8e3ed52a081da58eb4a885c157c594876633dbd4eb283f13ba5bf39c82322d76"},
+    {file = "Shapely-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7c8eda45085ccdd7f9805ea4a93fdd5eb0b6039a61d5f0cefb960487e6dc17a1"},
+    {file = "Shapely-1.8.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:beee3949ddf381735049cfa6532fb234d5d20a5be910c4f2fb7c7295fd7960e3"},
+    {file = "Shapely-1.8.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e07b0bd2a0e61a8afd4d1c1bd23f3550b711f01274ffb53de99358fd781eefd8"},
+    {file = "Shapely-1.8.2-cp37-cp37m-win32.whl", hash = "sha256:78966332a89813b237de357a03f612fd451a871fe6e26c12b6b71645fe8eee39"},
+    {file = "Shapely-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8fe641f1f61b3d43dd61b5a85d2ef023e6e19bf8f204a5160a1cb1ec645cbc09"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cec89a5617c0137f4678282e983c3d63bf838fb00cdf318cc555b4d8409f7130"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:68c8e18dc9dc8a198c3addc8c9596f64137101f566f04b96ecfca0b214cb8b12"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f12695662c3ad1e6031b3de98f191963d0f09de6d1a4988acd907405644032ba"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:15a856fbb588ad5d042784e00918c662902776452008c771ecba2ff615cd197a"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d74de394684d66e25e780b0359fda85be7766af85940fa2dfad728b1a815c71f"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f3fac625690f01f35af665649e993f15f924e740b5c0ac0376900655815521"},
+    {file = "Shapely-1.8.2-cp38-cp38-win32.whl", hash = "sha256:1d95842cc6bbbeab673061b63e70b07be9a375c15a60f4098f8fbd29f43af1b4"},
+    {file = "Shapely-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:a58e1f362f2091743e5e13212f5d5d16251a4bb63dd0ed587c652d3be9620d3a"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5254240eefc44139ab0d128faf671635d8bdd9c23955ee063d4d6b8f20073ae0"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75042e8039c79dd01f102bb288beace9dc2f49fc44a2dea875f9b697aa8cd30d"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0c0fd457ce477b1dced507a72f1e2084c9191bfcb8a1e09886990ebd02acf024"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6fcb28836ae93809de1dde73c03c9c24bab0ba2b2bf419ddb2aeb72c96d110e9"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:44d2832c1b706bf43101fda92831a083467cc4b4923a7ed17319ab599c1025d8"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:137f1369630408024a62ff79a437a5657e6c5b76b9cd352dde704b425acdb298"},
+    {file = "Shapely-1.8.2-cp39-cp39-win32.whl", hash = "sha256:2e02da2e988e74d61f15c720f9f613fab51942aae2dfeacdcb78eadece00e1f3"},
+    {file = "Shapely-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:3423299254deec075e79fb7dc7909d702104e4167149de7f45510c3a6342eeea"},
+    {file = "Shapely-1.8.2.tar.gz", hash = "sha256:572af9d5006fd5e3213e37ee548912b0341fb26724d6dc8a4e3950c10197ebb6"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ SQLAlchemy = "^1.4.36"
 greenlet = "^1.1.2"
 beautifulsoup4 = "^4.11.1"
 lxml = "^4.8.0"
+Shapely = "^1.8.2"
 
 [tool.poetry.dev-dependencies]
 black="^22.3.0"

--- a/server/main.py
+++ b/server/main.py
@@ -62,10 +62,9 @@ async def get_coastlines(
     response = await db_session.execute(stmt)
 
     """TODO
-    * Finish schema typing to support validation/serialization
-
     * Add error handling
     """
+
     return [schemas.Coastline.from_orm(row.Coastline).dict() for row in response]
 
 

--- a/server/schemas/buoy.py
+++ b/server/schemas/buoy.py
@@ -1,15 +1,16 @@
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from geoalchemy2.elements import WKBElement
+from pydantic import BaseModel, validator
 
+from .common import ewkb_to_wkt
 
-# TODO: fix typing to streamline API validation/serialization
 # Shared properties
 class BuoyBase(BaseModel):
     station_id: str
     name: str
     owner: str
-    location: Any  # Geography(geometry_type="POINT")
+    location: str  # Geography(geometry_type="POINT")
     elev: Optional[float] = 0.0  # elevation
     pgm: str
     type: str
@@ -18,6 +19,12 @@ class BuoyBase(BaseModel):
     waterquality: Optional[str] = "n"
     dart: Optional[str] = "n"
     seq: Optional[int] = None  # tao_seq
+
+    @validator("location", pre=True, allow_reuse=True, whole=True, always=True)
+    def correct_location_format(cls, v):
+        if not isinstance(v, WKBElement):
+            raise ValueError("Must be a valid WKBE element")
+        return ewkb_to_wkt(v)
 
 
 # Properties to receive on item creation

--- a/server/schemas/coastline.py
+++ b/server/schemas/coastline.py
@@ -1,15 +1,23 @@
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from geoalchemy2.elements import WKBElement
+from pydantic import BaseModel, validator
 
 from .buoy import Buoy
+from .common import ewkb_to_wkt
+
 
 
 # Shared properties
 class CoastlineBase(BaseModel):
-    # TODO: fix typing to streamline API validation/serialization
-    geom: Any  # Geography(geometry_type="MULTILINE")
+    geom: str  # Geography(geometry_type="MULTILINE")
     station_id: str
+
+    @validator("geom", pre=True, allow_reuse=True, whole=True, always=True)
+    def correct_geom_format(cls, v):
+        if not isinstance(v, WKBElement):
+            raise ValueError("Must be a valid WKBE element")
+        return ewkb_to_wkt(v)
 
 
 # Properties to receive on item creation
@@ -32,7 +40,6 @@ class CoastlineInDBBase(CoastlineBase):
 
 # Properties to return to client
 class Coastline(CoastlineInDBBase):
-    # TODO: fix typing to streamline API validation/serialization
     buoy: Optional[Buoy]
 
 

--- a/server/schemas/common.py
+++ b/server/schemas/common.py
@@ -1,0 +1,13 @@
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.shape import to_shape
+
+
+def ewkb_to_wkt(geom: WKBElement):
+    """
+    Converts a geometry formated as WKBE to WKT
+    in order to parse it into pydantic Model
+
+    Args:
+        geom (WKBElement): A geometry from GeoAlchemy query
+    """
+    return to_shape(geom).wkt


### PR DESCRIPTION
Fixes #5 

---

## Summary

- [x] Convert `WKBElement` to WKB as `str` with `Pydantic`'s validator decorator.
- [x] Add `Shapely` to dependency to support this conversion via `geoalchemy`.
- [x] Remove `Any` type declarations from all schema files.
- [x] Cleanup: remove TODOs associated with this task from code.

### API Demo

- `/api/v1/coastlines` now provides the following:

    <img width="1600" alt="Demo of coastlines endpoint" src="https://user-images.githubusercontent.com/47502769/170880941-86d71725-7c15-4cc5-8993-4b92944849a8.png">