### PR TITLE
fix: support server without PYTHONPATH env

### DIFF
--- a/.github/workflows/fastapi-server.yml
+++ b/.github/workflows/fastapi-server.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
-          PYTHONPATH: .:src
+          PYTHONPATH: $PYTHONPATH:.
         run: |
           sleep 10;
           poetry run alembic upgrade head
@@ -58,7 +58,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
-          PYTHONPATH: .:src
+          PYTHONPATH: $PYTHONPATH:.
         # TODO: incorporate coverage reporting
         run: |
           poetry run pytest

--- a/server/main.py
+++ b/server/main.py
@@ -1,3 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+# TODO: consolidate duplication of this block of code (seed_initial_data and conftest)
+# if __name__ == "__main__" and server folder is not on PYTHONPATH
+server_fpath = str(Path(os.path.join(os.path.dirname(__file__))).parent)
+if server_fpath not in sys.path:
+    sys.path.append(server_fpath)
+
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/server/prestart.sh
+++ b/server/prestart.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env sh
 
-echo "Running inside /server/prestart.sh, you could add migrations to this file, e.g.:"
+echo "Running inside /server/prestart.sh, you could add migrations to this file"
 
 echo "
 #!/bin/sh

--- a/server/seed_initial_data.py
+++ b/server/seed_initial_data.py
@@ -1,5 +1,13 @@
 import asyncio
 import logging
+import os
+import sys
+from pathlib import Path
+
+# if __name__ == "__main__" and server folder is not on PYTHONPATH
+server_fpath = str(Path(os.path.join(os.path.dirname(__file__))).parent)
+if server_fpath not in sys.path:
+    sys.path.append(server_fpath)
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,12 @@
 import inspect
+import os
+import sys
+from pathlib import Path
+
+# if __name__ == "__main__" and server folder is not on PYTHONPATH
+server_fpath = str(Path(os.path.join(os.path.dirname(__file__))).parent)
+if server_fpath not in sys.path:
+    sys.path.append(server_fpath)
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Description

Support file execution without needing the `PYTHONPATH` environment variable; this fix was applied to three files:
- `server/seed_initial_data.py`
- `server/main.py`
- `tests/*` (with `pytest`)

This simplifies developer environment setup and also production environment setup.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feat/310-new-endpoint` or `bug/322-fix-missing-param`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.

## Related Issues

Fixes #28