### PR TITLE
feat(buoys): provide lat and lon for location

### DIFF
--- a/server/schemas/buoy.py
+++ b/server/schemas/buoy.py
@@ -3,7 +3,7 @@ from typing import Optional
 from geoalchemy2.elements import WKBElement
 from pydantic import BaseModel, validator
 
-from .common import ewkb_to_wkt
+from .common import ewkb_to_coords
 
 
 # Shared properties
@@ -11,7 +11,7 @@ class BuoyBase(BaseModel):
     station_id: str
     name: str
     owner: str
-    location: str  # Geography(geometry_type="POINT")
+    location: tuple[float, float] | str  # [lon, lat] or POINT(lon lat)
     elev: Optional[float] = 0.0  # elevation
     pgm: str
     type: str
@@ -46,7 +46,7 @@ class Buoy(BuoyInDBBase):
     def correct_location_format(cls, v):
         if not isinstance(v, WKBElement):
             raise ValueError("Must be a valid WKBE element")
-        return ewkb_to_wkt(v)
+        return ewkb_to_coords(v)
 
 
 # Properties properties stored in DB

--- a/server/schemas/common.py
+++ b/server/schemas/common.py
@@ -11,3 +11,14 @@ def ewkb_to_wkt(geom: WKBElement):
         geom (WKBElement): A geometry from GeoAlchemy query
     """
     return to_shape(geom).wkt
+
+
+def ewkb_to_coords(geom: WKBElement):
+    """
+    Converts a Point formated as WKBE to an array
+    of coordinates in order to parse it into pydantic Model
+
+    Args:
+        geom (WKBElement): A geometry from GeoAlchemy query
+    """
+    return to_shape(geom).coords[0]

--- a/tests/api/test_buoys.py
+++ b/tests/api/test_buoys.py
@@ -13,7 +13,6 @@ def test_get_buoy(test_app):
     assert "station_id" in rockaway_buoy
     assert "name" in rockaway_buoy
     assert "owner" in rockaway_buoy
-    assert "location" in rockaway_buoy
     assert "elev" in rockaway_buoy
     assert "pgm" in rockaway_buoy
     assert "type" in rockaway_buoy
@@ -22,6 +21,12 @@ def test_get_buoy(test_app):
     assert "water_quality" in rockaway_buoy
     assert "dart" in rockaway_buoy
     assert "seq" in rockaway_buoy
+
+    assert "location" in rockaway_buoy
+    rockaway_buoy_location = rockaway_buoy["location"]
+    assert len(rockaway_buoy_location) == 2
+    assert rockaway_buoy_location[0] == -73.703
+    assert rockaway_buoy_location[1] == 40.369
 
 
 def test_get_buoys(test_app):


### PR DESCRIPTION
## Description

- Revise location attribute for every buoy to return `[longitude, latitude]` to support https://github.com/clairBuoyant/web/issues/3.
- Update tests to check for longitude and latitude.

### Example

- `GET /api/v1/buoys/44065`:

    <img width="587" alt="demo buoy response from api" src="https://user-images.githubusercontent.com/47502769/178801223-f0c55183-57e9-4689-ab0a-87c9dc51e367.png">


## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feat/310-new-endpoint` or `bug/322-fix-missing-param`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.

## Related Issues

Closes #35