### PR TITLE
chore: scaffold support for production deployments

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -2,19 +2,19 @@
 
 if [ -f /server/server/main.py ]; then
     DEFAULT_MODULE_NAME=server.main
-elif [ -f /server/main.py ]; then
+elif [ -f ~/server/main.py ]; then
     DEFAULT_MODULE_NAME=main
 fi
 MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
-VARIABLE_NAME=${VARIABLE_NAME:-server}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
 export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
 
 if [ -f /server/gunicorn_conf.py ]; then
     DEFAULT_GUNICORN_CONF=/server/gunicorn_conf.py
-elif [ -f /server/docker/gunicorn_conf.py ]; then
-    DEFAULT_GUNICORN_CONF=/server/docker/gunicorn_conf.py
+elif [ -f ~/server/docker/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=~/server/docker/gunicorn_conf.py
 else
-    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+    DEFAULT_GUNICORN_CONF=gunicorn_conf.py
 fi
 export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
 export WORKER_CLASS=${WORKER_CLASS:-"uvicorn.workers.UvicornWorker"}

--- a/server/api/api_router.py
+++ b/server/api/api_router.py
@@ -1,0 +1,27 @@
+from typing import Any, Callable
+
+from fastapi import APIRouter as FastAPIRouter
+from fastapi.types import DecoratedCallable
+
+
+class APIRouter(FastAPIRouter):
+    def api_route(
+        self, path: str, *, include_in_schema: bool = True, **kwargs: Any
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        if path.endswith("/"):
+            path = path[:-1]
+
+        add_path = super().api_route(
+            path, include_in_schema=include_in_schema, **kwargs
+        )
+
+        alternate_path = path + "/"
+        add_alternate_path = super().api_route(
+            alternate_path, include_in_schema=False, **kwargs
+        )
+
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            add_alternate_path(func)
+            return add_path(func)
+
+        return decorator

--- a/server/api/v1/api.py
+++ b/server/api/v1/api.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter
-
+from server.api.api_router import APIRouter
 from server.api.v1.endpoints import buoys, coastlines, meteorological_data, wave_data
 from server.core.constants import (
     BUOYS_PATH,

--- a/server/api/v1/endpoints/buoys.py
+++ b/server/api/v1/endpoints/buoys.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from server.api.api_router import APIRouter
 from server.api.dependencies import get_db
 from server.core.constants import RELATIVE_ROOT
 from server.crud.crud_buoy import buoy

--- a/server/api/v1/endpoints/coastlines.py
+++ b/server/api/v1/endpoints/coastlines.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from server.api.api_router import APIRouter
 from server.api.dependencies import get_db
 from server.core.constants import RELATIVE_ROOT
 from server.crud import coastline

--- a/server/api/v1/endpoints/meteorological_data.py
+++ b/server/api/v1/endpoints/meteorological_data.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from server.api.api_router import APIRouter
 from server.api.dependencies import get_db
 from server.core.constants import RELATIVE_ROOT
 from server.crud import meteorological_datum

--- a/server/api/v1/endpoints/wave_data.py
+++ b/server/api/v1/endpoints/wave_data.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from server.api.api_router import APIRouter
 from server.api.dependencies import get_db
 from server.core.constants import RELATIVE_ROOT
 from server.crud.crud_wave_datum import wave_datum

--- a/server/main.py
+++ b/server/main.py
@@ -53,7 +53,14 @@ def get_application() -> FastAPI:
     )
 
     # TODO: Specify specific hosts and adjust method/header permissions
-    origins = ["localhost"]
+    origins = [
+        "clairbuoyant.live",
+        "dev.clairbuoyant.live",
+        "http://127.0.0.1:3000",
+        "https://clairbuoyant.live",
+        "https://dev.clairbuoyant.live",
+        "https://*.web-dpa.pages.dev",
+    ]
 
     application.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
### Summary

- [x] Address `FastAPI` bug: 307 Temporary Redirect errors were caused due to implicit requirement to provide trailing slash on all requests.
- [x] Fix file path guards and variable name for docker start script.
- [x] Update allowed origins list to account for production environment.
    - _NOTE: these production configurations are still a WIP._ 