### PR TITLE
chore: lint and format with ruff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 __pycache__
 .coverage
 .docker
+.DS_Store
 .git
 .github
 .gitignore
@@ -9,8 +10,8 @@ __pycache__
 .mypy_cache
 .pytest_cache
 .python-version
+.ruff_cache
 .vscode
-.DS_Store
 
 coverage
 htmlcov

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-doc-length = 72
-max-line-length = 88
-extend-ignore = E203

--- a/.gitignore
+++ b/.gitignore
@@ -27,38 +27,39 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 coverage
 htmlcov/
-.tox/
-.nox/
+nosetests.xml
+.cache
 .coverage
 .coverage.*
-.cache
-nosetests.xml
+.hypothesis/
+.nox/
+.pytest_cache/
+.ruff_cache
+.tox/
 *.cover
 *.py,cover
-.hypothesis/
-.pytest_cache/
 
 ## Misc
+__pypackages__/
 .DS_Store
 .idea
 .idea_modules
 .python-version
-__pypackages__/
 
 ## mypy
-.mypy_cache/
 .dmypy.json
+.mypy_cache/
 dmypy.json
 
 ## Sphinx documentation
 docs/_build/
 
 ## VSCode
-.vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
 !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/*
 *.code-workspace
 
 ## Exceptions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: branch-validate
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.13.0
+    rev: v3.21.3
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -17,34 +17,17 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
       - id: forbid-tabs
       - id: remove-tabs
-  - repo: https://github.com/lovesegfault/beautysh
-    rev: v6.2.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
     hooks:
-      - id: beautysh
-  - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
-    hooks:
-      - id: absolufy-imports
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-black>=0.3.6
-        args: ["--config=.flake8"]
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy

--- a/migrations/versions/6fc1a99cefd5_create_coastlines.py
+++ b/migrations/versions/6fc1a99cefd5_create_coastlines.py
@@ -5,6 +5,7 @@ Revises: d632ea3490c4
 Create Date: 2022-05-21 14:48:54.624485
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from geoalchemy2.types import Geography  # type: ignore

--- a/migrations/versions/d632ea3490c4_create_buoys.py
+++ b/migrations/versions/d632ea3490c4_create_buoys.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-12-25 20:31:21.052080
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from geoalchemy2.types import Geography  # type: ignore

--- a/migrations/versions/d63493af0a71_create_meteorological_wave_data.py
+++ b/migrations/versions/d63493af0a71_create_meteorological_wave_data.py
@@ -5,6 +5,7 @@ Revises: 6fc1a99cefd5
 Create Date: 2022-08-20 14:01:00.212730
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/ed4ad564e77b_add_forecasts.py
+++ b/migrations/versions/ed4ad564e77b_add_forecasts.py
@@ -1,10 +1,11 @@
-""" Add Forecasts
+"""Add Forecasts
 
 Revision ID: 0d4ad564e77b
 Revises: d63493af0a71
 Create Date: 2023-03-26 12:46:10.999340
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -119,50 +119,6 @@ docs = ["Sphinx (>=5.3.0,<5.4.0)", "sphinx-rtd-theme (>=1.2.2)", "sphinxcontrib-
 test = ["flake8 (>=6.1,<7.0)", "uvloop (>=0.15.3)"]
 
 [[package]]
-name = "black"
-version = "24.3.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-24.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395"},
-    {file = "black-24.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995"},
-    {file = "black-24.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"},
-    {file = "black-24.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0"},
-    {file = "black-24.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9"},
-    {file = "black-24.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597"},
-    {file = "black-24.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d"},
-    {file = "black-24.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5"},
-    {file = "black-24.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f"},
-    {file = "black-24.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11"},
-    {file = "black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4"},
-    {file = "black-24.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5"},
-    {file = "black-24.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837"},
-    {file = "black-24.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd"},
-    {file = "black-24.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213"},
-    {file = "black-24.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959"},
-    {file = "black-24.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb"},
-    {file = "black-24.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7"},
-    {file = "black-24.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7"},
-    {file = "black-24.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f"},
-    {file = "black-24.3.0-py3-none-any.whl", hash = "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93"},
-    {file = "black-24.3.0.tar.gz", hash = "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -419,22 +375,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", 
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "flake8"
-version = "7.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"},
-    {file = "flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.2.0,<3.3.0"
-
-[[package]]
 name = "geoalchemy2"
 version = "0.14.7"
 description = "Using SQLAlchemy with Spatial Databases"
@@ -634,20 +574,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "lxml"
@@ -867,17 +793,6 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mypy"
 version = "1.9.0"
 description = "Optional static typing for Python"
@@ -1005,17 +920,6 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -1077,17 +981,6 @@ files = [
 [package.dependencies]
 lxml = ">=5.1.0,<6.0.0"
 requests = ">=2.31.0,<3.0.0"
-
-[[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
 
 [[package]]
 name = "pydantic"
@@ -1217,17 +1110,6 @@ python-dotenv = ">=0.21.0"
 [package.extras]
 toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
-]
 
 [[package]]
 name = "pytest"
@@ -1378,6 +1260,32 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "ruff"
+version = "0.3.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.3.4-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:60c870a7d46efcbc8385d27ec07fe534ac32f3b251e4fc44b3cbfd9e09609ef4"},
+    {file = "ruff-0.3.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6fc14fa742e1d8f24910e1fff0bd5e26d395b0e0e04cc1b15c7c5e5fe5b4af91"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3ee7880f653cc03749a3bfea720cf2a192e4f884925b0cf7eecce82f0ce5854"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf133dd744f2470b347f602452a88e70dadfbe0fcfb5fd46e093d55da65f82f7"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f3860057590e810c7ffea75669bdc6927bfd91e29b4baa9258fd48b540a4365"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:986f2377f7cf12efac1f515fc1a5b753c000ed1e0a6de96747cdf2da20a1b369"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fd98e85869603e65f554fdc5cddf0712e352fe6e61d29d5a6fe087ec82b76c"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64abeed785dad51801b423fa51840b1764b35d6c461ea8caef9cf9e5e5ab34d9"},
+    {file = "ruff-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df52972138318bc7546d92348a1ee58449bc3f9eaf0db278906eb511889c4b50"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:98e98300056445ba2cc27d0b325fd044dc17fcc38e4e4d2c7711585bd0a958ed"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:519cf6a0ebed244dce1dc8aecd3dc99add7a2ee15bb68cf19588bb5bf58e0488"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bb0acfb921030d00070539c038cd24bb1df73a2981e9f55942514af8b17be94e"},
+    {file = "ruff-0.3.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cf187a7e7098233d0d0c71175375c5162f880126c4c716fa28a8ac418dcf3378"},
+    {file = "ruff-0.3.4-py3-none-win32.whl", hash = "sha256:af27ac187c0a331e8ef91d84bf1c3c6a5dea97e912a7560ac0cef25c526a4102"},
+    {file = "ruff-0.3.4-py3-none-win_amd64.whl", hash = "sha256:de0d5069b165e5a32b3c6ffbb81c350b1e3d3483347196ffdf86dc0ef9e37dd6"},
+    {file = "ruff-0.3.4-py3-none-win_arm64.whl", hash = "sha256:6810563cc08ad0096b57c717bd78aeac888a1bfd38654d9113cb3dc4d3f74232"},
+    {file = "ruff-0.3.4.tar.gz", hash = "sha256:f0f4484c6541a99862b693e13a151435a279b271cff20e37101116a21e2a1ad1"},
+]
 
 [[package]]
 name = "setuptools"
@@ -1636,4 +1544,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <4.0"
-content-hash = "a4b345b8b2a878eb1820b00922035a3d3891148dda2cc6f37634410ad6a1a992"
+content-hash = "748441dd83eba91c7fc6675fb1fb9026c1eff569d7eed34852c1c93a386a945b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,14 @@ SQLAlchemy = "^2.0.29"
 uvicorn = "^0.29.0"
 
 [tool.poetry.dev-dependencies]
-black="^24.3.0"
 coverage = { version = "7.4.4", extras = ["toml"]}
-flake8 = "^7.0.0"
 httpx = "^0.27.0"
-isort = { version = "^5.13.2", extras = ["pyproject"]}
 mypy = "^1.9.0"
 pre-commit = "^3.7.0"
 pytest-asyncio = "^0.23.6"
 pytest-cov = "^5.0.0"
 pytest="^8.1.1"
+ruff = "^0.3.4"
 
 [tool.poetry.scripts]
 bootstrap="scripts.poetry_entrypoint:bootstrap"
@@ -52,22 +50,17 @@ start="scripts.poetry_entrypoint:start"
 test="scripts.poetry_entrypoint:test"
 uninstall="scripts.poetry_entrypoint:uninstall"
 
-[tool.black]
-# https://github.com/psf/black
+[tool.ruff]
+exclude = [
+  ".git",
+  ".mypy_cache",
+  ".pytest_cache",
+  "htmlcov",
+  "venv",
+  ".venv",
+]
 line-length = 88
-target_version = ['py310']
-exclude = '''
-(
-  /(
-    \.git
-    | \.mypy_cache
-    | \.pytest_cache
-    | htmlcov
-    | venv
-    | .venv
-  )/
-)
-'''
+target-version = "py311"
 
 [tool.coverage]
 # https://github.com/nedbat/coveragepy
@@ -85,9 +78,6 @@ exclude = '''
     "raise NotImplementedError",
     "if __name__ == \"__main__\":",
   ]
-
-[tool.isort]
-profile="black"
 
 [tool.mypy]
 explicit_package_bases = true

--- a/scripts/check
+++ b/scripts/check
@@ -13,7 +13,5 @@ fi
 CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 BASE_DIR="$(dirname "$CURRENT_DIR")"
 
-${PREFIX}black --check --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
-${PREFIX}isort --check --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
-${PREFIX}flake8 --config="${BASE_DIR}/.flake8" "${BASE_DIR}/${APP}"
+${PREFIX}ruff check
 ${PREFIX}mypy --config-file "${BASE_DIR}/pyproject.toml" -p "${APP}"

--- a/scripts/lint
+++ b/scripts/lint
@@ -2,17 +2,11 @@
 #
 # Run code linting.
 
-APP='server'
-
-CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-BASE_DIR="$(dirname "$CURRENT_DIR")"
-
 if [ -d '.venv' ] ; then
     PREFIX='.venv/bin/'
 else
     PREFIX=''
 fi
 
-${PREFIX}black --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
-${PREFIX}isort --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
-${PREFIX}flake8 --config="${BASE_DIR}/.flake8" "${BASE_DIR}/${APP}"
+${PREFIX}ruff check --select I --fix # until unified command is added to format and sort imports
+${PREFIX}ruff format

--- a/server/db/events.py
+++ b/server/db/events.py
@@ -4,6 +4,7 @@ TODO: https://docs.sqlalchemy.org/en/14/core/connections.html
     * Investigate any advantages managing connections ourselves.
     * Alternative: `get_db` with Dependency hook for every request.
 """
+
 import logging
 
 import asyncpg  # type: ignore

--- a/server/schemas/buoy.py
+++ b/server/schemas/buoy.py
@@ -23,13 +23,11 @@ class BuoyBase(BaseModel):
 
 
 # Properties to receive on item creation
-class BuoyCreate(BuoyBase):
-    ...
+class BuoyCreate(BuoyBase): ...
 
 
 # Properties to receive on item update
-class BuoyUpdate(BuoyBase):
-    ...
+class BuoyUpdate(BuoyBase): ...
 
 
 # Properties shared by models stored in DB
@@ -50,5 +48,4 @@ class Buoy(BuoyInDBBase):
 
 
 # Properties properties stored in DB
-class BuoyInDB(BuoyInDBBase):
-    ...
+class BuoyInDB(BuoyInDBBase): ...

--- a/server/schemas/coastline.py
+++ b/server/schemas/coastline.py
@@ -14,13 +14,11 @@ class CoastlineBase(BaseModel):
 
 
 # Properties to receive on item creation
-class CoastlineCreate(CoastlineBase):
-    ...
+class CoastlineCreate(CoastlineBase): ...
 
 
 # Properties to receive on item update
-class CoastlineUpdate(CoastlineBase):
-    ...
+class CoastlineUpdate(CoastlineBase): ...
 
 
 # Properties shared by models stored in DB
@@ -43,5 +41,4 @@ class Coastline(CoastlineInDBBase):
 
 
 # Properties properties stored in DB
-class CoastlineInDB(CoastlineInDBBase):
-    ...
+class CoastlineInDB(CoastlineInDBBase): ...

--- a/server/schemas/forecast.py
+++ b/server/schemas/forecast.py
@@ -15,13 +15,11 @@ class ForecastBase(BaseModel):
 
 
 # Properties to receive on item creation
-class ForecastCreate(ForecastBase):
-    ...
+class ForecastCreate(ForecastBase): ...
 
 
 # Properties to receive on item update
-class ForecastUpdate(ForecastBase):
-    ...
+class ForecastUpdate(ForecastBase): ...
 
 
 # Properties shared by models stored in DB
@@ -30,8 +28,7 @@ class ForecastInDBBase(ForecastBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class Forecast(ForecastInDBBase):
-    ...
+class Forecast(ForecastInDBBase): ...
 
 
 # Properties properties stored in DB

--- a/server/schemas/meteorological_datum.py
+++ b/server/schemas/meteorological_datum.py
@@ -25,13 +25,11 @@ class MeteorologicalDatumBase(BaseModel):
 
 
 # Properties to receive on item creation
-class MeteorologicalDatumCreate(MeteorologicalDatumBase):
-    ...
+class MeteorologicalDatumCreate(MeteorologicalDatumBase): ...
 
 
 # Properties to receive on item update
-class MeteorologicalDatumUpdate(MeteorologicalDatumBase):
-    ...
+class MeteorologicalDatumUpdate(MeteorologicalDatumBase): ...
 
 
 # Properties shared by models stored in DB
@@ -40,10 +38,8 @@ class MeteorologicalDatumInDBBase(MeteorologicalDatumBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class MeteorologicalDatum(MeteorologicalDatumInDBBase):
-    ...
+class MeteorologicalDatum(MeteorologicalDatumInDBBase): ...
 
 
 # Properties properties stored in DB
-class MeteorologicalDatumInDB(MeteorologicalDatumInDBBase):
-    ...
+class MeteorologicalDatumInDB(MeteorologicalDatumInDBBase): ...

--- a/server/schemas/wave_datum.py
+++ b/server/schemas/wave_datum.py
@@ -21,13 +21,11 @@ class WaveDatumBase(BaseModel):
 
 
 # Properties to receive on item creation
-class WaveDatumCreate(WaveDatumBase):
-    ...
+class WaveDatumCreate(WaveDatumBase): ...
 
 
 # Properties to receive on item update
-class WaveDatumUpdate(WaveDatumBase):
-    ...
+class WaveDatumUpdate(WaveDatumBase): ...
 
 
 # Properties shared by models stored in DB
@@ -36,10 +34,8 @@ class WaveDatumInDBBase(WaveDatumBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class WaveDatum(WaveDatumInDBBase):
-    ...
+class WaveDatum(WaveDatumInDBBase): ...
 
 
 # Properties properties stored in DB
-class WaveDatumInDB(WaveDatumInDBBase):
-    ...
+class WaveDatumInDB(WaveDatumInDBBase): ...


### PR DESCRIPTION
### Summary

- Add [`ruff`](https://github.com/astral-sh/ruff) as dev dependency to lint and format.
- Remove `black`, `flake8`, and `isort`.
- Update [`pre-commit`](https://pre-commit.com) hooks.