### PR TITLE
chore(github): set workflow permissions

### DIFF
--- a/.github/workflows/fastapi-server.yml
+++ b/.github/workflows/fastapi-server.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   test-server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for [https://github.com/clairBuoyant/server/security/code-scanning/1](https://github.com/clairBuoyant/server/security/code-scanning/1) by adding `permissions` block at the root of the workflow file to explicitly define the minimal permissions required.

---


_Suggested fixes powered by Copilot Autofix._
